### PR TITLE
Assign default code ownership to @emphori/open-source

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @emphori/open-source


### PR DESCRIPTION
This PR closes #15.